### PR TITLE
Corrige HistoriaViewPageAdapter.

### DIFF
--- a/app/src/main/java/com/gradientepolimorfico/monedapp/Activities/MainActivity.kt
+++ b/app/src/main/java/com/gradientepolimorfico/monedapp/Activities/MainActivity.kt
@@ -137,7 +137,6 @@ class MainActivity : AppCompatActivity(){
         supportFragmentManager
                 .beginTransaction()
                 .replace(containerViewId,fragment)
-                .addToBackStack(null)
                 .commit()
     }
 

--- a/app/src/main/java/com/gradientepolimorfico/monedapp/Activities/MainActivity.kt
+++ b/app/src/main/java/com/gradientepolimorfico/monedapp/Activities/MainActivity.kt
@@ -31,7 +31,6 @@ class MainActivity : AppCompatActivity(){
     var historialFragment   : HistorialFragment?    = null
     var divisaBase          : Divisa?               = null
     var historialAdapter    : HistoriaPageAdapter?  = null
-    var fragments           = ArrayList<Fragment>()
     var cambioEnMonedaBase : Boolean = false
 
     private fun init(){
@@ -94,23 +93,9 @@ class MainActivity : AppCompatActivity(){
 
     public fun iniciarFragmentsPagers(pager: ViewPager?, manager : FragmentManager){
         val adapter = HistoriaPageAdapter(manager)
-
-        if(this.fragments.isEmpty() || this.cambioEnMonedaBase){
-            //Log.d("I","PRINCIPAL --- VACIO O CAMBIO EN MONEDA")
-            this.cambioEnMonedaBase = false
-            this.fragments.clear()
-            var iterador = this.getDivisasIterator()
-            iterador.forEach {
-                d ->
-                var fragment = HistoriaFragment()
-                fragment.agregarDivisa(d)
-                this.fragments.add(fragment)
-                //Log.d("I","PRINCIPAL --- "+d.codigo)
-            }
-        }
        // Log.d("I","PRINCIPAL ---"+this.fragments.count().toString())
         //Log.d("I","PRINCIPAL ---"+(this.fragments[0] as HistoriaFragment).divisa!!.codigo)
-        adapter.agregarFragments(this.fragments)
+        adapter.agregarDivisas(getDivisas())
         //Log.d("I","PRINCIPAL ---"+(adapter.getItem(0) as HistoriaFragment).divisa!!.codigo)
         adapter.notifyDataSetChanged()
         pager?.adapter = adapter

--- a/app/src/main/java/com/gradientepolimorfico/monedapp/Adapters/HistoriaPageAdapter.kt
+++ b/app/src/main/java/com/gradientepolimorfico/monedapp/Adapters/HistoriaPageAdapter.kt
@@ -3,10 +3,11 @@ package com.gradientepolimorfico.monedapp.Adapters
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import android.support.v4.app.FragmentPagerAdapter
+import com.gradientepolimorfico.monedapp.Entities.Divisa
 import com.gradientepolimorfico.monedapp.Fragments.HistoriaFragment
 
 class HistoriaPageAdapter : FragmentPagerAdapter {
-    private var fragments = ArrayList<Fragment>()
+    private var divisas = ArrayList<Divisa>()
     private val titles = ArrayList<String>()
 
     constructor(fm: FragmentManager?) : super(fm){
@@ -14,31 +15,31 @@ class HistoriaPageAdapter : FragmentPagerAdapter {
     }
 
     override fun getItem(position: Int): Fragment {
-        return this.fragments[position]
+        return HistoriaFragment().also { it.agregarDivisa(divisas[position]) }
     }
 
     override fun getCount(): Int {
-        return this.fragments.size
+        return this.divisas.size
     }
 
     override fun getItemId(position: Int): Long {
-        return (fragments[position] as HistoriaFragment?)?.divisa?.bandera?.toLong() ?: super.getItemId(position)
+        return divisas[position].bandera?.toLong() ?: super.getItemId(position)
     }
 
-    fun agregarFragments(fragments : ArrayList<Fragment>){
-        this.fragments.clear()
-        this.fragments = fragments
+    fun agregarDivisas(fragments : ArrayList<Divisa>){
+        this.divisas.clear()
+        this.divisas = fragments
     }
 
     override fun getPageTitle(position: Int): CharSequence {
         return titles[position]
     }
 
-    fun removeFragment(position: Int){
-        this.fragments.remove(this.getItem(position))
+    fun removeDivisa(position: Int){
+        this.divisas.removeAt(position)
     }
 
-    fun addFragment(fragment: Fragment){
-        this.fragments.add(fragment)
+    fun addDivisa(divisa: Divisa){
+        this.divisas.add(divisa)
     }
 }

--- a/app/src/main/java/com/gradientepolimorfico/monedapp/Adapters/HistoriaPageAdapter.kt
+++ b/app/src/main/java/com/gradientepolimorfico/monedapp/Adapters/HistoriaPageAdapter.kt
@@ -2,10 +2,10 @@ package com.gradientepolimorfico.monedapp.Adapters
 
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
-import android.support.v4.app.FragmentStatePagerAdapter
-import android.support.v4.view.PagerAdapter
+import android.support.v4.app.FragmentPagerAdapter
+import com.gradientepolimorfico.monedapp.Fragments.HistoriaFragment
 
-class HistoriaPageAdapter : FragmentStatePagerAdapter {
+class HistoriaPageAdapter : FragmentPagerAdapter {
     private var fragments = ArrayList<Fragment>()
     private val titles = ArrayList<String>()
 
@@ -21,8 +21,8 @@ class HistoriaPageAdapter : FragmentStatePagerAdapter {
         return this.fragments.size
     }
 
-    override fun getItemPosition(`object`: Any): Int {
-        return PagerAdapter.POSITION_NONE
+    override fun getItemId(position: Int): Long {
+        return (fragments[position] as HistoriaFragment?)?.divisa?.bandera?.toLong() ?: super.getItemId(position)
     }
 
     fun agregarFragments(fragments : ArrayList<Fragment>){


### PR DESCRIPTION
`FragmentStatePagerAdapter` y `FragmentPagerAdapter` deberían, en principio, no ser inicializados con fragments, sino con la información necesaria para generar esos fragments. La diferencia entre estos dos es que el primero (el que estaban usando ustedes) es más agresivo en el manejo de los fragments y los instancia y destruye según haga falta para reducir el consumo de memoria y está pensado para cuando el viewpager tiene muchas páginas. Como ustedes no instancian los fragments a demanda (sino que ya los tienen instanciados) y este adapter los destruye cuando quiere es que fallaba moverse entre tabs. Cambiando al segundo no tienen este problema.
Con los dos tienen otro problema, que es que los fragments se cachean (recuerden que la idea es instanciarlos, no devolverlos de un array) por lo tanto, al cambiar la lista, las páginas ya generadas no se vuelven a generar. Al cambiar el orden de los fragments (cuando cambian las divisas) es necesario reordenarlos y ahí entra en juego el itemId. Por default usa la posición, entonces no detecta cambios en el orden. Para corregirlo puse como itemId la bandera de la divisa. No es lo mejor, pero ustedes pueden cambiarlo por algo más apropiado.
Y de paso les quité el addToBackStack porque se mambeaba todo al navegar por la aplicación.